### PR TITLE
feat: allow for reorder call if same index

### DIFF
--- a/src/components/ReorderableList.tsx
+++ b/src/components/ReorderableList.tsx
@@ -53,6 +53,7 @@ const ReorderableList = <T,>(
     onLayout,
     onReorder,
     keyExtractor,
+    callReorderSameIndex = false,
     ...rest
   }: ReorderableListProps<T>,
   ref: React.ForwardedRef<FlatListProps<T>>,
@@ -168,7 +169,7 @@ const ReorderableList = <T,>(
   );
 
   const reorder = (fromIndex: number, toIndex: number) => {
-    if (fromIndex !== toIndex) {
+    if (fromIndex !== toIndex || callReorderSameIndex) {
       unstable_batchedUpdates(() => {
         onReorder({fromIndex, toIndex});
         enableDragged(false);

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -39,6 +39,7 @@ export interface ReorderableListProps<T>
   scrollAreaSize?: number;
   scrollSpeed?: number;
   dragScale?: number;
+  callReorderSameIndex?: boolean;
   renderItem: (info: ReorderableListRenderItemInfo<T>) => React.ReactElement;
   onReorder: (event: ReorderableListReorderEvent) => void;
 }


### PR DESCRIPTION
This will allow for a flag to be passed so onReorder will be called if the from and to indexs are the same.

This acts as a `onTouchEnd` hook so we know when the dragging has stopped for any element.