### PR TITLE
Use drag direction to determine autoscroll trigger

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2540,7 +2540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.25.0":
+"@babel/preset-typescript@npm:^7.16.7":
   version: 7.26.0
   resolution: "@babel/preset-typescript@npm:7.26.0"
   dependencies:
@@ -4017,22 +4017,21 @@ __metadata:
   linkType: hard
 
 "@types/react-test-renderer@npm:^18.3.1":
-  version: 18.3.0
-  resolution: "@types/react-test-renderer@npm:18.3.0"
+  version: 18.3.1
+  resolution: "@types/react-test-renderer@npm:18.3.1"
   dependencies:
-    "@types/react": "npm:*"
-  checksum: 10/c53683990bd194cb68e3987bda79c78eff41517f7a747e92f3e54217c2ce3addd031b8a45bf631982c909cc2caeeb905372f322758e05bb76c03754a3f24426e
+    "@types/react": "npm:^18"
+  checksum: 10/f8cc23cc8decdb6068cdc8f8c306e189eab8e569443ce97b216e757ee42eb20b18d2280ef41e2955668413f14be92765a3ba86cfcfeeae6b20c965acd9674786
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.2.14
-  resolution: "@types/react@npm:18.2.14"
+"@types/react@npm:^18":
+  version: 18.3.18
+  resolution: "@types/react@npm:18.3.18"
   dependencies:
     "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/9a8e9a6e6d39dba32a449ac986add435ee30d1f5af336efa7b0cb0e8e31eefa2b85ab2ef921284b373e820c47d184c7161f826cc77f1e528cc13642be3596110
+  checksum: 10/7fdd8b853e0d291d4138133f93f8d5c333da918e5804afcea61a923aab4bdfc9bb15eb21a5640959b452972b8715ddf10ffb12b3bd071898b9e37738636463f2
   languageName: node
   linkType: hard
 
@@ -4043,13 +4042,6 @@ __metadata:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10/d1321e874e6523b0a944d4ce514c071cbe44501b04591e17c0b265c9a03fb3e4486337ae1bec74541b72a41f34beef157342205dd07b31d116f4d06fa39cf32f
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.16.3
-  resolution: "@types/scheduler@npm:0.16.3"
-  checksum: 10/2b0aec39c24268e3ce938c5db2f2e77f5c3dd280e05c262d9c2fe7d890929e4632a6b8e94334017b66b45e4f92a5aa42ba3356640c2a1175fa37bef2f5200767
   languageName: node
   linkType: hard
 
@@ -10030,7 +10022,7 @@ __metadata:
     "@babel/plugin-transform-shorthand-properties": "npm:^7.0.0-0"
     "@babel/plugin-transform-template-literals": "npm:^7.0.0-0"
     "@babel/plugin-transform-unicode-regex": "npm:^7.0.0-0"
-    "@babel/preset-typescript": "npm:^7.25.0"
+    "@babel/preset-typescript": "npm:^7.16.7"
     convert-source-map: "npm:^2.0.0"
     invariant: "npm:^2.2.4"
   peerDependencies:

--- a/src/components/ReorderableListCore/useReorderableListCore.ts
+++ b/src/components/ReorderableListCore/useReorderableListCore.ts
@@ -582,17 +582,18 @@ export const useReorderableListCore = <T>({
       ) {
         setCurrentIndex(y);
 
-        // Trigger scrolls when:
+        // Trigger autoscroll when:
         // 1. Within the threshold area (top or bottom of list)
         // 2. Have dragged in the same direction as the scroll
+        // 3. Not already in autoscroll mode
         const currentDragDirection = currentTranslationY.value > 0 ? 1 : -1;
-        if (
-          state.value === ReorderableListState.DRAGGED &&
-          currentDragDirection === scrollDirection(y)
-        ) {
-          lastAutoscrollTrigger.value = autoscrollTrigger.value;
-          autoscrollTrigger.value *= -1;
-          state.value = ReorderableListState.AUTOSCROLL;
+        if (currentDragDirection === scrollDirection(y)) {
+          // If the first two conditions are met, but it's already in autoscroll mode we let it continue (no-op)
+          if (state.value !== ReorderableListState.AUTOSCROLL) {
+            state.value = ReorderableListState.AUTOSCROLL;
+            lastAutoscrollTrigger.value = autoscrollTrigger.value;
+            autoscrollTrigger.value *= -1;
+          }
         } else if (state.value === ReorderableListState.AUTOSCROLL) {
           state.value = ReorderableListState.DRAGGED;
         }

--- a/src/components/ReorderableListCore/useReorderableListCore.ts
+++ b/src/components/ReorderableListCore/useReorderableListCore.ts
@@ -582,9 +582,14 @@ export const useReorderableListCore = <T>({
       ) {
         setCurrentIndex(y);
 
-        if (scrollDirection(y) !== 0) {
-          if (state.value !== ReorderableListState.AUTOSCROLL) {
-            // trigger autoscroll
+        const _dragDirection = currentTranslationY.value > 0 ? 1 : -1;
+        const _scrollDirection = scrollDirection(y);
+
+        if (state.value !== ReorderableListState.AUTOSCROLL) {
+          // Trigger scrolls when:
+          // 1. Within the threshold area (top or bottom of list)
+          // 2. Have dragged in the same direction as the scroll
+          if (_scrollDirection === _dragDirection) {
             lastAutoscrollTrigger.value = autoscrollTrigger.value;
             autoscrollTrigger.value *= -1;
             state.value = ReorderableListState.AUTOSCROLL;

--- a/src/components/ReorderableListCore/useReorderableListCore.ts
+++ b/src/components/ReorderableListCore/useReorderableListCore.ts
@@ -582,18 +582,17 @@ export const useReorderableListCore = <T>({
       ) {
         setCurrentIndex(y);
 
-        const _dragDirection = currentTranslationY.value > 0 ? 1 : -1;
-        const _scrollDirection = scrollDirection(y);
-
-        if (state.value !== ReorderableListState.AUTOSCROLL) {
-          // Trigger scrolls when:
-          // 1. Within the threshold area (top or bottom of list)
-          // 2. Have dragged in the same direction as the scroll
-          if (_scrollDirection === _dragDirection) {
-            lastAutoscrollTrigger.value = autoscrollTrigger.value;
-            autoscrollTrigger.value *= -1;
-            state.value = ReorderableListState.AUTOSCROLL;
-          }
+        // Trigger scrolls when:
+        // 1. Within the threshold area (top or bottom of list)
+        // 2. Have dragged in the same direction as the scroll
+        const currentDragDirection = currentTranslationY.value > 0 ? 1 : -1;
+        if (
+          state.value === ReorderableListState.DRAGGED &&
+          currentDragDirection === scrollDirection(y)
+        ) {
+          lastAutoscrollTrigger.value = autoscrollTrigger.value;
+          autoscrollTrigger.value *= -1;
+          state.value = ReorderableListState.AUTOSCROLL;
         } else if (state.value === ReorderableListState.AUTOSCROLL) {
           state.value = ReorderableListState.DRAGGED;
         }

--- a/src/components/ReorderableListCore/useReorderableListCore.ts
+++ b/src/components/ReorderableListCore/useReorderableListCore.ts
@@ -588,7 +588,7 @@ export const useReorderableListCore = <T>({
         // 3. Not already in autoscroll mode
         const currentDragDirection = currentTranslationY.value > 0 ? 1 : -1;
         if (currentDragDirection === scrollDirection(y)) {
-          // If the first two conditions are met, but it's already in autoscroll mode we let it continue (no-op)
+          // When the first two conditions are met and it's already in autoscroll mode, we let it continue (no-op)
           if (state.value !== ReorderableListState.AUTOSCROLL) {
             state.value = ReorderableListState.AUTOSCROLL;
             lastAutoscrollTrigger.value = autoscrollTrigger.value;

--- a/src/components/ReorderableListCore/useReorderableListCore.ts
+++ b/src/components/ReorderableListCore/useReorderableListCore.ts
@@ -175,15 +175,14 @@ export const useReorderableListCore = <T>({
   const setDragDirection = useCallback(
     (e: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
       'worklet';
+
       const direction = e.velocityY > 0 ? 1 : -1;
       if (direction !== dragDirection.value) {
         if (lastDragDirectionPivot.value === null) {
           lastDragDirectionPivot.value = e.absoluteY;
-        } else {
-          if (Math.abs(e.absoluteY - lastDragDirectionPivot.value) >= 10) {
-            dragDirection.value = direction;
-            lastDragDirectionPivot.value = e.absoluteY;
-          }
+        } else if (Math.abs(e.absoluteY - lastDragDirectionPivot.value) >= 10) {
+          dragDirection.value = direction;
+          lastDragDirectionPivot.value = e.absoluteY;
         }
       }
     },
@@ -207,6 +206,7 @@ export const useReorderableListCore = <T>({
           if (state.value === ReorderableListState.DRAGGED) {
             setDragDirection(e);
           }
+
           if (state.value !== ReorderableListState.RELEASED) {
             currentY.value = startY.value + e.translationY;
             currentTranslationY.value = e.translationY;
@@ -220,7 +220,7 @@ export const useReorderableListCore = <T>({
         .onEnd(e => (gestureState.value = e.state))
         .onFinalize(e => (gestureState.value = e.state)),
     [
-      state.value,
+      state,
       startY,
       currentY,
       currentTranslationY,

--- a/src/components/ReorderableListCore/useReorderableListCore.ts
+++ b/src/components/ReorderableListCore/useReorderableListCore.ts
@@ -204,10 +204,7 @@ export const useReorderableListCore = <T>({
           }
         })
         .onUpdate(e => {
-          if (
-            state.value === ReorderableListState.DRAGGED ||
-            state.value === ReorderableListState.AUTOSCROLL // <- comment this out to try only canceling when leaving the region
-          ) {
+          if (state.value === ReorderableListState.DRAGGED) {
             setDragDirection(e);
           }
           if (state.value !== ReorderableListState.RELEASED) {


### PR DESCRIPTION
Closes #33 

The bug:
When dragging an item that *starts* in an autoscroll region, the autoscroll is immediately triggered, even if the intended scroll direction would have been against the scroll. 

The solution:
Use `currentTranslationY`, which is synced with the Pan gesture drag delta, to determine if the trigger was caused by moving into the drag region.

After:
https://github.com/user-attachments/assets/8e6b7122-f730-476b-86ff-5460da914878



