### PR TITLE
Fix: Prevent "ghost" drag behavior after item deletion

### DIFF
--- a/example/src/Playlist/PlaylistItem.tsx
+++ b/example/src/Playlist/PlaylistItem.tsx
@@ -1,5 +1,12 @@
 import React, {memo} from 'react';
-import {Image, Pressable, StyleSheet, Text, View} from 'react-native';
+import {
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import {useReorderableDrag} from 'react-native-reorderable-list';
 
@@ -7,11 +14,17 @@ interface PlaylistItemProps {
   image: string;
   title: string;
   author: string;
+  id: string;
+  deleteItem: (id: string) => void;
 }
 
 export const PlaylistItem: React.FC<PlaylistItemProps> = memo(
-  ({image, title, author}) => {
+  ({image, title, author, deleteItem, id}) => {
     const drag = useReorderableDrag();
+
+    const handleDelete = () => {
+      deleteItem(id);
+    };
 
     return (
       <Pressable style={styles.container} onLongPress={drag}>
@@ -27,6 +40,9 @@ export const PlaylistItem: React.FC<PlaylistItemProps> = memo(
           </Text>
           <Text style={styles.author}>{author}</Text>
         </View>
+        <TouchableOpacity onPress={handleDelete} style={styles.delete}>
+          <Text>X</Text>
+        </TouchableOpacity>
       </Pressable>
     );
   },
@@ -39,6 +55,15 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     padding: 12,
   },
+  delete: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: 'lightgrey',
+    color: 'white',
+    borderRadius: 4,
+    fontWeight: 'bold',
+  },
+
   image: {
     height: 50,
     width: 50,

--- a/example/src/Playlist/PlaylistScreen.tsx
+++ b/example/src/Playlist/PlaylistScreen.tsx
@@ -39,8 +39,12 @@ export const PlaylistScreen = () => {
     setData(value => reorderItems(value, from, to));
   };
 
+  const deleteItem = (id: string) => {
+    setData(prev => [...prev.filter(track => track.id !== id)]);
+  };
+
   const renderItem = ({item}: ListRenderItemInfo<PlaylistItemData>) => (
-    <PlaylistItem {...item} />
+    <PlaylistItem deleteItem={deleteItem} {...item} />
   );
 
   return (

--- a/src/components/ReorderableListCell.tsx
+++ b/src/components/ReorderableListCell.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useMemo} from 'react';
+import React, {memo, useCallback, useEffect, useMemo} from 'react';
 import {CellRendererProps, LayoutChangeEvent} from 'react-native';
 
 import Animated, {
@@ -138,6 +138,15 @@ export const ReorderableListCell = memo(
 
       onLayout?.(e);
     };
+
+    useEffect(() => {
+      return () => {
+        runOnUI((idx: number) => {
+          itemOffset.value[idx] = 0;
+          itemHeight.value[idx] = 0;
+        })(index);
+      };
+    }, [index, itemOffset, itemHeight]);
 
     return (
       <ReorderableCellContext.Provider value={contextValue}>


### PR DESCRIPTION
## Which Problems Are Solved
When an item is deleted from the list, its position could still be incorrectly used as a valid drop target for a dragged item.

## How the Problems Are Solved
Set `itemOffset` and `itemHeight` value to 0 for the unmounting index

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/78215bc3-7040-426a-95f5-748c94984b39) | ![after](https://github.com/user-attachments/assets/77405155-f0ac-40f7-8047-4221f4afb46a) | 

