### PR TITLE
fix: https://github.com/omahili/react-native-reorderable-list/issues/56

### DIFF
--- a/src/components/ReorderableListCore.tsx
+++ b/src/components/ReorderableListCore.tsx
@@ -481,9 +481,8 @@ const ReorderableListCore = <T,>(
   const reorder = (fromIndex: number, toIndex: number) => {
     runOnUI(resetSharedValues)();
 
-    markCells(fromIndex, toIndex);
-
     if (fromIndex !== toIndex) {
+      markCells(fromIndex, toIndex);
       onReorder({from: fromIndex, to: toIndex});
     }
   };


### PR DESCRIPTION
I believe the issue is caused by modifying the internal marks/state even when no reordering actually occurs. In that case, the next real reordering might reuse the same key for the "moved" cell, which can prevent the component from recognizing it as a new instance. This could result in the view not updating properly (e.g., translation mismatch after drop)